### PR TITLE
Mod load fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/*
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-node_modules/*
-package-lock.json

--- a/module/insim/classes/mods.js
+++ b/module/insim/classes/mods.js
@@ -31,7 +31,13 @@ class ModsHandler {
         }
         else {
             const fileData = fs.readFileSync(filePath);
-            const mods = fileData.toString().split('\n').filter(mod => mod.length > 0 && mod.length < 4);
+            let EoLSequence = "";
+
+            if (fileData.toString().includes("\r")) {
+                EoLSequence = "\r";
+            }
+
+            const mods = fileData.toString().split(EoLSequence + '\n').filter(mod => mod.length > 0 && mod.length <= 6);
             console.log('[InSim.Mods.loadFile]: file loaded. Mods count: ' + mods.length);
 
             this.mods = mods;


### PR DESCRIPTION
i noticed mods aren't loading from the file it's saved in because of 2 reasons:

- on CRLF systems the string becomes max 8 characters, thus the condition is always false, so i added an extra check to look for carriage returns.

- Mods work with SkinIDs, and those can be up to 6 characters long, so i also increased the max length it should look for.

tested with both CRLF and LF files
also tested the mod loading, loading from file works.

i might look at the automatic mod loading from server soon.